### PR TITLE
Dependency graph tester UI

### DIFF
--- a/dependency-graph/src/main/java/com/electricmind/dependency/graph/Grapher.java
+++ b/dependency-graph/src/main/java/com/electricmind/dependency/graph/Grapher.java
@@ -47,12 +47,12 @@ public class Grapher<T> {
 		this.dependencyManager = dependencyManager;
 	}
 
-	protected synchronized void draw(Graphics2D graphics, Rectangle2D rectangle) {
+	public synchronized void draw(Graphics2D graphics, Rectangle2D rectangle) {
 		double scale = calculateScale(rectangle);
 		draw(graphics, rectangle, scale);
 	}
 
-	private synchronized void initialize() {
+	public synchronized void initialize() {
 		this.shape.setPlot(this.plot);
 		this.arrowShape.setPlot(this.plot);
 		this.graph = new SugiyamaAlgorithm().apply(this.dependencyManager);
@@ -65,21 +65,21 @@ public class Grapher<T> {
 			}
 		}
 	}
-	
+
 	public void setStripeColour(Color color) {
 		this.plot.setLayerAlternatingColor(color);
 	}
-	
+
 	public Color getStripeColour() {
 		return this.plot.getLayerAlternatingColor();
 	}
-	
+
 	private synchronized void draw(Graphics2D graphics, Rectangle2D rectangle, double scale) {
 		rectangle = scale(scale, rectangle);
 		graphics.scale(1.0/scale, 1.0/scale);
-		
+
 		this.shape.initialize(graphics, this.dependencyManager.getLayeredGraph().getNodes());
-		
+
 		drawLayerBars(graphics, rectangle);
 
 		this.coordinateSystem = new CoordinateSystem(this.shape, this.graph.getHeight());
@@ -90,31 +90,31 @@ public class Grapher<T> {
 				rectangle.getY(),
 				rectangle.getWidth() - (2 * getLeftBorder()), rectangle.getHeight());
 
-		
+
 		drawBoxes(graphics);
 		drawArrows(graphics);
 	}
-	
+
 	private synchronized void drawSvg(Dimension dimension, OutputStream output) throws IOException {
 		BufferedImage image = new BufferedImage(
-				(int) Math.ceil(this.shape.getDimension().getWidth()), 
-				(int) Math.ceil(this.shape.getDimension().getHeight()), 
+				(int) Math.ceil(this.shape.getDimension().getWidth()),
+				(int) Math.ceil(this.shape.getDimension().getHeight()),
 				BufferedImage.TYPE_INT_ARGB);
 		Graphics2D g2 = image.createGraphics();
 		this.shape.initialize(g2, this.dependencyManager.getLayeredGraph().getNodes());
 		g2.dispose();
-		
+
 		drawLayerBarsSvg(dimension, output);
-		
+
 		this.coordinateSystem = new CoordinateSystem(this.shape, this.graph.getHeight());
 		double excessWidth = dimension.getWidth() - this.coordinateSystem.getWidth(this.graph.getWidth());
 		double excessHeight = dimension.getHeight() - this.coordinateSystem.getTotalHeight();
-		
+
 		output.write(("<g transform=\"translate(" + (excessWidth / 2.0) + "," + excessHeight + ")\" >").getBytes("UTF-8"));
-		
+
 		drawBoxesSvg(output);
 		drawArrowsSvg(output);
-		
+
 		output.write("</g>".getBytes("UTF-8"));
 	}
 
@@ -137,7 +137,7 @@ public class Grapher<T> {
 		double height = layers.size() * getLayerBandHeight();
 		double shapeWidth = this.shape.getWidth();
 		double width = this.graph.getWidth() * shapeWidth * WIDTH_SCALE_FACTOR + getLeftBorder();
-		
+
 		Dimension dimension = new Dimension();
 		dimension.setSize(width, height);
 		return dimension;
@@ -184,14 +184,14 @@ public class Grapher<T> {
 			Node<T> node = (Node<T>) ((Graph.BasicVertex) vertex).getNode();
 			Object object = ((Graph.BasicVertex) dependency).getNode().getItem();
 			float width = determineStrokeWidth(node, object);
-			
+
 			Arrow line = BoundsUtil.getEndPoints(getBounds(node.getItem()), getBounds(object));
 			line.setWidth(width);
 			this.arrowShape.drawArrowSvg(output, line);
 			if (((BasicVertex) vertex).isBidirectionalWith((BasicVertex) dependency)) {
 				Point2D to = getBoundsCenter(node.getItem(), 0.05 * this.shape.getWidth());
 				Point2D from = getBoundsCenter(object, 0.05 * this.shape.getWidth());
-				
+
 				Arrow arrow = new Arrow(Arrays.asList(from, to));
 				arrow = arrow.clipEnd(getBounds(node.getItem()));
 				arrow = arrow.clipStart(getBounds(object));
@@ -207,27 +207,27 @@ public class Grapher<T> {
 		float width = 1.0f;
 		if (this.plot.isUseWeights()) {
 			int weight = determineWeight(node, object);
-			
+
 			if (this.maxWeight > 1) {
 				width = (float) (1 + 4 * (Math.sqrt(weight) / Math.sqrt(this.maxWeight)));
 			}
 		}
 		return width;
 	}
-	
+
 	private void drawArrow(Graphics2D graphics, Vertex vertex, Vertex dependency) {
 		if (!dependency.isDummy() && !vertex.isDummy()) {
 			Node<T> node = (Node<T>) ((Graph.BasicVertex) vertex).getNode();
 			Object object = ((Graph.BasicVertex) dependency).getNode().getItem();
 			float width = determineStrokeWidth(node, object);
-			
+
 			Arrow line = BoundsUtil.getEndPoints(getBounds(node.getItem()), getBounds(object));
 			line.setWidth(width);
 			this.arrowShape.drawArrow(graphics, line);
 			if (((BasicVertex) vertex).isBidirectionalWith((BasicVertex) dependency)) {
 				Point2D to = getBoundsCenter(node.getItem(), 0.05 * this.shape.getWidth());
 				Point2D from = getBoundsCenter(object, 0.05 * this.shape.getWidth());
-				
+
 				Arrow arrow = new Arrow(Arrays.asList(from, to));
 				arrow = arrow.clipEnd(getBounds(node.getItem()));
 				arrow = arrow.clipStart(getBounds(object));
@@ -253,24 +253,24 @@ public class Grapher<T> {
 	private Arrow getArrow(Vertex dependency) {
 		DummyVertex lastDummy = getLastDummy((DummyVertex) dependency);
 		Vertex end = lastDummy.getLower();
-		
+
 		DummyVertex firstDummy = getFirstDummy((DummyVertex) dependency);
 		Vertex start = firstDummy.getUpper();
-		
+
 		Node<T> node = (Node<T>) ((Graph.BasicVertex) start).getNode();
 		Object object = ((Graph.BasicVertex) end).getNode().getItem();
 		float width = determineStrokeWidth(node, object);
-		
+
 		boolean reversed = end.getLayer() > start.getLayer();
-		
+
 		Vertex previous = reversed ? end : start;
 		Point2D.Double point1 = new Point2D.Double(this.coordinateSystem.getCenterX(dependency),
 				this.coordinateSystem.getTopY(reversed ? lastDummy : firstDummy ));
 		Arrow arrow = BoundsUtil.getEndPoints(getBounds(previous), point1);
-		
-		for (Vertex v = reversed ? lastDummy : firstDummy; v.isDummy(); 
+
+		for (Vertex v = reversed ? lastDummy : firstDummy; v.isDummy();
 				v = reversed ? ((DummyVertex) v).getLower() : ((DummyVertex) v).getUpper()) {
-			
+
 			if (previous.isDummy()) {
 				Point2D top = new Point2D.Double(this.coordinateSystem.getCenterX(previous),
 						this.coordinateSystem.getBottomY(previous));
@@ -327,7 +327,7 @@ public class Grapher<T> {
 			drawLayerSvg(i, layers.get(i), output);
 		}
 	}
-	
+
 	private void drawLayer(Graphics2D graphics, int layerNumber, GraphLayer layer) {
 		for (Vertex vertex : layer.getOrderedContents()) {
 			this.coordinateSystem.getCenterX(vertex);
@@ -380,7 +380,7 @@ public class Grapher<T> {
 			alternate = !alternate;
 		}
 	}
-	
+
 	private void drawLayerBarsSvg(Dimension dimension, OutputStream output) throws IOException {
 		double height = getLayerBandHeight();
 		String fill = ColorUtil.asHtml(getStripeColour());
@@ -419,16 +419,16 @@ public class Grapher<T> {
 	public synchronized Dimension createSvg(OutputStream output) throws IOException {
 		initialize();
 		final Dimension dimension = getPreferredDimension();
-		
+
 		output.write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>".getBytes("UTF-8"));
-		output.write(("<svg width=\"" + dimension.getWidth() + "\" height=\"" + dimension.getHeight() +  "\" viewBox=\"0 0 " 
-				+ dimension.getWidth() + " " + dimension.getHeight() 
+		output.write(("<svg width=\"" + dimension.getWidth() + "\" height=\"" + dimension.getHeight() +  "\" viewBox=\"0 0 "
+				+ dimension.getWidth() + " " + dimension.getHeight()
 				+ "\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">").getBytes("UTF-8"));
 		output.write("<g>".getBytes("UTF-8"));
 		drawSvg(dimension, output);
 		output.write("</g>".getBytes("UTF-8"));
 		output.write("</svg>".getBytes("UTF-8"));
-		
+
 		return dimension;
 	}
 

--- a/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/ComplicatedPackageGraphCrossings.java
+++ b/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/ComplicatedPackageGraphCrossings.java
@@ -1,27 +1,23 @@
 package com.electricmind.dependency.graph.shape;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-
-import org.apache.commons.lang3.SystemUtils;
-
 import com.electricmind.dependency.DependencyManager;
 import com.electricmind.dependency.graph.Grapher;
 
-public class ComplicatedPackageGraphCrossings {
+public class ComplicatedPackageGraphCrossings extends DependencyGraphTester<String> {
 
 	public static void main(String[] args) throws Exception {
 		new ComplicatedPackageGraphCrossings().process();
 	}
 
-	/**
-	 * @throws FileNotFoundException
-	 * @throws IOException
-	 */
-	private void process() throws FileNotFoundException, IOException {
+	@Override
+	public Grapher<String> createGrapher(DependencyManager<String> manager) {
+		Grapher<String> grapher = new Grapher<String>(manager);
+		grapher.setShape(new PackageShape<String>());
+		return grapher;
+	}
+
+	@Override
+	public DependencyManager<String> createManager() {
 		DependencyManager<String> manager = new DependencyManager<String>();
 		manager.add("ca.intelliware.ereferral.converter");
 		manager.add("ca.intelliware.ereferral.util.security");
@@ -273,25 +269,6 @@ public class ComplicatedPackageGraphCrossings {
 
 		manager.add("ca.intelliware.ereferral.webservice.client",
 				"ca.intelliware.ereferral.soap");
-
-		File file = new File(SystemUtils.JAVA_IO_TMPDIR, "ComplicatedPackageGraphCrossings.png");
-		System.out.println(file.getAbsolutePath());
-		OutputStream output = new FileOutputStream(file);
-		try {
-			Grapher<String> grapher = new Grapher<String>(manager);
-			grapher.setShape(new PackageShape<String>());
-			grapher.createPng(output);
-		} finally {
-			output.close();
-		}
-		
-		File svg = new File(SystemUtils.JAVA_IO_TMPDIR, "ComplicatedPackageGraphCrossings.svg");
-		System.out.println(svg.getAbsolutePath());
-		try (OutputStream outputSvg = new FileOutputStream(svg)) {
-			Grapher<String> grapher = new Grapher<String>(manager);
-			grapher.setShape(new PackageShape<String>());
-			grapher.createSvg(outputSvg);
-		}
-
+		return manager;
 	}
 }

--- a/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/DependencyGraphTester.java
+++ b/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/DependencyGraphTester.java
@@ -1,0 +1,63 @@
+package com.electricmind.dependency.graph.shape;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.apache.commons.lang3.SystemUtils;
+
+import com.electricmind.dependency.DependencyManager;
+import com.electricmind.dependency.graph.Grapher;
+
+public abstract class DependencyGraphTester<E> {
+	public abstract DependencyManager<E> createManager();
+
+	public abstract Grapher<E> createGrapher(DependencyManager<E> manager);
+
+	public void process() throws FileNotFoundException, IOException {
+		DependencyManager<E> manager = createManager();
+		Grapher<E> grapher = createGrapher(manager);
+		graphAll(grapher);
+	}
+
+	/**
+	 * Graphs to PNG and SVG.
+	 * Override if you only want to graph only to PNG or SVG, or you want a PNG with explicit width and height.
+	 * @param grapher
+	 * @throws IOException
+	 */
+	public void graphAll(Grapher<E> grapher) throws IOException {
+		graphToPng(grapher);
+		graphToSvg(grapher);
+	}
+
+	public String getFileNameBase() { return getClass().getSimpleName(); }
+
+	public void graphToPng(Grapher<E> grapher) throws IOException {
+		File file = new File(SystemUtils.JAVA_IO_TMPDIR, getFileNameBase() + ".png");
+		try (OutputStream output = new FileOutputStream(file)) {
+			grapher.createPng(output);
+		}
+	}
+
+	public void graphToPng(Grapher<E> grapher, int width, int height) throws IOException {
+		File file = new File(SystemUtils.JAVA_IO_TMPDIR, getFileNameBase() + ".png");
+		try (OutputStream output = new FileOutputStream(file)) {
+			grapher.createPng(output, width, height);
+		}
+	}
+
+	public void graphToSvg(Grapher<E> grapher) throws IOException {
+		File file = new File(SystemUtils.JAVA_IO_TMPDIR, getFileNameBase() + ".svg");
+		try (OutputStream output = new FileOutputStream(file)) {
+			grapher.createSvg(output);
+		}
+	}
+
+	@Override
+	public String toString() {
+		return getFileNameBase();
+	}
+}

--- a/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/DependencyGraphTesterUi.java
+++ b/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/DependencyGraphTesterUi.java
@@ -46,6 +46,9 @@ public class DependencyGraphTesterUi extends JFrame {
 		selectionModel.addListSelectionListener(new ListSelectionListener() {
 			@Override
 			public void valueChanged(ListSelectionEvent e) {
+				if (e.getValueIsAdjusting()) {
+					return;
+				}
 				int selIdx = selectionModel.getMinSelectionIndex();
 				@SuppressWarnings("unchecked")
 				DependencyGraphTester<String> item = selIdx >= 0 ?
@@ -73,19 +76,21 @@ public class DependencyGraphTesterUi extends JFrame {
 			tester = value;
 			manager = tester == null ? null : tester.createManager();
 			grapher = tester == null ? null : tester.createGrapher(manager);
-			grapher.initialize();
-			setSize(grapher.getShape().getDimension());
-
-			repaint();
+			if (grapher != null) {
+				grapher.initialize();
+				setSize(grapher.getShape().getDimension());
+			} else {
+				repaint();
+			}
 		}
 
 		@Override
 		protected void paintComponent(Graphics g) {
+			super.paintComponent(g);
+
 			if (grapher == null) {
-				super.paintComponent(g);
 				return;
 			}
-			super.paintComponent(g);
 
 			grapher.draw((Graphics2D)g, getBounds());
 		}

--- a/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/DependencyGraphTesterUi.java
+++ b/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/DependencyGraphTesterUi.java
@@ -1,0 +1,111 @@
+package com.electricmind.dependency.graph.shape;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.JFrame;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ListSelectionModel;
+import javax.swing.SwingUtilities;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+
+import com.electricmind.dependency.DependencyManager;
+import com.electricmind.dependency.graph.Grapher;
+
+public class DependencyGraphTesterUi extends JFrame {
+	private static final long serialVersionUID = 1L;
+
+	public static void main(String[] args) {
+		SwingUtilities.invokeLater(() -> launch());
+	}
+
+	private static void launch() {
+		DependencyGraphTesterUi ui = new DependencyGraphTesterUi();
+		ui.setVisible(true);
+	}
+
+	public DependencyGraphTesterUi() {
+		super("Dependency Graph Tester UI");
+		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		DependencyGraphTester<?>[] testers = createTesters();
+		JList<DependencyGraphTester<?>> testersList = new JList<>(testers);
+		add(testersList, BorderLayout.WEST);
+
+		GrapherUi<String> grapherUi = new GrapherUi<String>();
+
+		add(new JScrollPane(grapherUi), BorderLayout.CENTER);
+
+		ListSelectionModel selectionModel = testersList.getSelectionModel();
+		selectionModel.addListSelectionListener(new ListSelectionListener() {
+			@Override
+			public void valueChanged(ListSelectionEvent e) {
+				int selIdx = selectionModel.getMinSelectionIndex();
+				@SuppressWarnings("unchecked")
+				DependencyGraphTester<String> item = selIdx >= 0 ?
+						(DependencyGraphTester<String>) testersList.getModel().getElementAt(selIdx) : null;
+				grapherUi.setTester(item);
+			}
+		});
+
+		pack();
+	}
+
+	public static final class GrapherUi<T> extends JPanel {
+		private static final long serialVersionUID = 1L;
+
+		private DependencyGraphTester<T> tester;
+		private DependencyManager<T> manager;
+		private Grapher<T> grapher;
+
+		public GrapherUi() {
+			setPreferredSize(new Dimension(800, 600));
+			setOpaque(true);
+		}
+
+		public void setTester(DependencyGraphTester<T> value) {
+			tester = value;
+			manager = tester == null ? null : tester.createManager();
+			grapher = tester == null ? null : tester.createGrapher(manager);
+			grapher.initialize();
+			setSize(grapher.getShape().getDimension());
+
+			repaint();
+		}
+
+		@Override
+		protected void paintComponent(Graphics g)
+		{
+			if (grapher == null) {
+				super.paintComponent(g);
+				return;
+			}
+			super.paintComponent(g);
+
+			grapher.draw((Graphics2D)g, getBounds());
+		}
+	}
+
+	private DependencyGraphTester<?>[] createTesters()
+	{
+		List<DependencyGraphTester<?>> testers = new ArrayList<>();
+		testers.add(new SimpleArtifactGraph());
+		testers.add(new SimplePackageGraph());
+		testers.add(new PackageGraphWithCrossings());
+		testers.add(new PackageGraphWithSimpleCycles());
+		testers.add(new PackageGraphWithMultiplePrefixes());
+		testers.add(new PackageGraphWithAmbiguousCrossings());
+		testers.add(new SimpleNodeDiagram());
+		testers.add(new RandomNodesDiagram(20, 100));
+		testers.add(new RandomNodesDiagram(30, 150));
+		testers.add(new RandomNodesDiagram(50, 400));
+		testers.add(new ComplicatedPackageGraphCrossings());
+		return testers.toArray(new DependencyGraphTester<?>[testers.size()]);
+	}
+}

--- a/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/DependencyGraphTesterUi.java
+++ b/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/DependencyGraphTesterUi.java
@@ -80,8 +80,7 @@ public class DependencyGraphTesterUi extends JFrame {
 		}
 
 		@Override
-		protected void paintComponent(Graphics g)
-		{
+		protected void paintComponent(Graphics g) {
 			if (grapher == null) {
 				super.paintComponent(g);
 				return;
@@ -92,8 +91,7 @@ public class DependencyGraphTesterUi extends JFrame {
 		}
 	}
 
-	private DependencyGraphTester<?>[] createTesters()
-	{
+	private DependencyGraphTester<?>[] createTesters() {
 		List<DependencyGraphTester<?>> testers = new ArrayList<>();
 		testers.add(new SimpleArtifactGraph());
 		testers.add(new SimplePackageGraph());

--- a/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/PackageGraphWithAmbiguousCrossings.java
+++ b/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/PackageGraphWithAmbiguousCrossings.java
@@ -1,23 +1,31 @@
 package com.electricmind.dependency.graph.shape;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-
-import org.apache.commons.lang3.SystemUtils;
 
 import com.electricmind.dependency.DependencyManager;
 import com.electricmind.dependency.graph.Grapher;
 
-public class PackageGraphWithAmbiguousCrossings {
-	
+public class PackageGraphWithAmbiguousCrossings extends DependencyGraphTester<String> {
+
 	public static void main(String[] args) throws Exception {
 		new PackageGraphWithAmbiguousCrossings().process();
 	}
 
-	private void process() throws FileNotFoundException, IOException {
+	@Override
+	public void graphAll(Grapher<String> grapher) throws IOException {
+		super.graphToPng(grapher);
+	}
+
+	@Override
+	public Grapher<String> createGrapher(DependencyManager<String> manager)
+	{
+		Grapher<String> grapher = new Grapher<String>(manager);
+		grapher.setShape(new BigPackageShape<String>());
+		return grapher;
+	}
+
+	@Override
+	public DependencyManager<String> createManager() {
 		DependencyManager<String> manager = new DependencyManager<String>();
 		manager.add("a1", "b1");
 		manager.add("a2", "b2");
@@ -25,7 +33,7 @@ public class PackageGraphWithAmbiguousCrossings {
 		manager.add("a2", "b4");
 		manager.add("a2", "b1");
 		manager.add("a3", "b5");
-		
+
 		manager.add("b1", "c1");
 		manager.add("b1", "c2");
 		manager.add("b2", "c1");
@@ -35,20 +43,10 @@ public class PackageGraphWithAmbiguousCrossings {
 		manager.add("b4", "c3");
 		manager.add("b5", "c2");
 //		manager.add("b5", "c3");
-		
+
 		manager.add("c1", "d1");
 		manager.add("c2", "d1");
 		manager.add("c3", "d1");
-
-		File file = new File(SystemUtils.JAVA_IO_TMPDIR, "PackageGraphWithAmbiguousCrossings.png");
-		System.out.println(file.getAbsolutePath());
-		OutputStream output = new FileOutputStream(file);
-		try {
-			Grapher<String> grapher = new Grapher<String>(manager);
-			grapher.setShape(new BigPackageShape<String>());
-			grapher.createPng(output);
-		} finally {
-			output.close();
-		}
+		return manager;
 	}
 }

--- a/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/PackageGraphWithCrossings.java
+++ b/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/PackageGraphWithCrossings.java
@@ -1,43 +1,29 @@
 package com.electricmind.dependency.graph.shape;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-
-import org.apache.commons.lang3.SystemUtils;
-
 import com.electricmind.dependency.DependencyManager;
 import com.electricmind.dependency.graph.Grapher;
 
-public class PackageGraphWithCrossings {
-	
+public class PackageGraphWithCrossings extends DependencyGraphTester<String> {
+
 	public static void main(String[] args) throws Exception {
 		new PackageGraphWithCrossings().process();
 	}
 
-	private void process() throws FileNotFoundException, IOException {
+	@Override
+	public Grapher<String> createGrapher(DependencyManager<String> manager)
+	{
+		Grapher<String> grapher = new Grapher<String>(manager);
+		grapher.setShape(new BigPackageShape<String>());
+		return grapher;
+	}
+
+	@Override
+	public DependencyManager<String> createManager() {
 		DependencyManager<String> manager = new DependencyManager<String>();
 		manager.add("ca.intelliware.example.sub1", "ca.intelliware.example.sub2");
 		manager.add("ca.intelliware.example.sub1", "ca.intelliware.example");
 		manager.add("ca.intelliware.example.sub3", "ca.intelliware.example.sub2");
 		manager.add("ca.intelliware.example.sub3", "ca.intelliware.example");
-
-		File file = new File(SystemUtils.JAVA_IO_TMPDIR, "PackageGraphWithCrossings.png");
-		System.out.println(file.getAbsolutePath());
-		try (OutputStream output = new FileOutputStream(file)) {
-			Grapher<String> grapher = new Grapher<String>(manager);
-			grapher.setShape(new BigPackageShape<String>());
-			grapher.createPng(output);
-		}
-		
-		File svg = new File(SystemUtils.JAVA_IO_TMPDIR, "PackageGraphWithCrossings.svg");
-		System.out.println(svg.getAbsolutePath());
-		try (OutputStream outputSvg = new FileOutputStream(svg)) {
-			Grapher<String> grapher = new Grapher<String>(manager);
-			grapher.setShape(new BigPackageShape<String>());
-			grapher.createSvg(outputSvg);
-		}
+		return manager;
 	}
 }

--- a/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/PackageGraphWithCrossings.java
+++ b/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/PackageGraphWithCrossings.java
@@ -10,8 +10,7 @@ public class PackageGraphWithCrossings extends DependencyGraphTester<String> {
 	}
 
 	@Override
-	public Grapher<String> createGrapher(DependencyManager<String> manager)
-	{
+	public Grapher<String> createGrapher(DependencyManager<String> manager) {
 		Grapher<String> grapher = new Grapher<String>(manager);
 		grapher.setShape(new BigPackageShape<String>());
 		return grapher;

--- a/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/PackageGraphWithCycles.java
+++ b/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/PackageGraphWithCycles.java
@@ -1,24 +1,31 @@
 package com.electricmind.dependency.graph.shape;
 
-import java.awt.Dimension;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-
-import org.apache.commons.lang3.SystemUtils;
 
 import com.electricmind.dependency.DependencyManager;
 import com.electricmind.dependency.graph.Grapher;
 
-public class PackageGraphWithCycles {
-	
+public class PackageGraphWithCycles extends DependencyGraphTester<String> {
+
 	public static void main(String[] args) throws Exception {
 		new PackageGraphWithCycles().process();
 	}
 
-	private void process() throws FileNotFoundException, IOException {
+	@Override
+	public Grapher<String> createGrapher(DependencyManager<String> manager)
+	{
+		Grapher<String> grapher = new Grapher<String>(manager);
+		grapher.setShape(new PackageShape<String>());
+		return grapher;
+	}
+
+	@Override
+	public void graphAll(Grapher<String> grapher) throws IOException {
+		super.graphToPng(grapher);
+	}
+
+	@Override
+	public DependencyManager<String> createManager() {
 		DependencyManager<String> manager = new DependencyManager<String>();
 		manager.add("ca.intelliware.example.sub1", "ca.intelliware.example.sub2");
 		manager.add("ca.intelliware.example.sub1", "ca.intelliware.example");
@@ -27,17 +34,6 @@ public class PackageGraphWithCycles {
 		manager.add("ca.intelliware.example.sub2", "ca.intelliware.example.sub4");
 		manager.add("ca.intelliware.example.sub4", "ca.intelliware.example.sub5");
 		manager.add("ca.intelliware.example", "ca.intelliware.example.sub3");
-
-		File file = new File(SystemUtils.JAVA_IO_TMPDIR, "PackageGraphWithCycles.png");
-		System.out.println(file.getAbsolutePath());
-		OutputStream output = new FileOutputStream(file);
-		try {
-			Grapher<String> grapher = new Grapher<String>(manager);
-			grapher.setShape(new PackageShape<String>());
-			Dimension d = grapher.createPng(output);
-			System.out.println(d);
-		} finally {
-			output.close();
-		}
+		return manager;
 	}
 }

--- a/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/PackageGraphWithCycles.java
+++ b/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/PackageGraphWithCycles.java
@@ -12,8 +12,7 @@ public class PackageGraphWithCycles extends DependencyGraphTester<String> {
 	}
 
 	@Override
-	public Grapher<String> createGrapher(DependencyManager<String> manager)
-	{
+	public Grapher<String> createGrapher(DependencyManager<String> manager) {
 		Grapher<String> grapher = new Grapher<String>(manager);
 		grapher.setShape(new PackageShape<String>());
 		return grapher;

--- a/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/PackageGraphWithMultiplePrefixes.java
+++ b/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/PackageGraphWithMultiplePrefixes.java
@@ -1,40 +1,34 @@
 package com.electricmind.dependency.graph.shape;
 
-import java.awt.Dimension;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-
-import org.apache.commons.lang3.SystemUtils;
 
 import com.electricmind.dependency.DependencyManager;
 import com.electricmind.dependency.graph.Grapher;
 
-public class PackageGraphWithMultiplePrefixes {
+public class PackageGraphWithMultiplePrefixes extends DependencyGraphTester<String> {
 	public static void main(String[] args) throws Exception {
 		new PackageGraphWithMultiplePrefixes().process();
 	}
 
-	private void process() throws FileNotFoundException, IOException {
+	@Override
+	public Grapher<String> createGrapher(DependencyManager<String> manager) {
+		Grapher<String> grapher = new Grapher<String>(manager);
+		grapher.setShape(new PackageShape<String>());
+		return grapher;
+	}
+
+	@Override
+	public void graphAll(Grapher<String> grapher) throws IOException {
+		super.graphToSvg(grapher);
+	}
+
+	@Override
+	public DependencyManager<String> createManager() {
 		DependencyManager<String> manager = new DependencyManager<String>();
 		manager.add("ca.intelliware.example.sub1", "ca.intelliware.example");
 		manager.add("ca.intelliware.example.sub4", "ca.intelliware.example.sub5");
 		manager.add("com.electricmind.example.sub5", "ca.intelliware.example.sub4");
 		manager.add("com.electricmind.example.sub6", "ca.intelliware.example.sub4");
-
-		File file = new File(SystemUtils.JAVA_IO_TMPDIR, "PackageGraphWithMultiplePrefixes.svg");
-		System.out.println(file.getAbsolutePath());
-		OutputStream output = new FileOutputStream(file);
-		try {
-			Grapher<String> grapher = new Grapher<String>(manager);
-			grapher.setShape(new PackageShape<String>());
-			Dimension d = grapher.createSvg(output);
-			System.out.println(d);
-		} finally {
-			output.close();
-		}
+		return manager;
 	}
-
 }

--- a/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/PackageGraphWithSimpleCycles.java
+++ b/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/PackageGraphWithSimpleCycles.java
@@ -1,37 +1,34 @@
 package com.electricmind.dependency.graph.shape;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-
-import org.apache.commons.lang3.SystemUtils;
 
 import com.electricmind.dependency.DependencyManager;
 import com.electricmind.dependency.graph.Grapher;
 
-public class PackageGraphWithSimpleCycles {
-	
+public class PackageGraphWithSimpleCycles extends DependencyGraphTester<String> {
+
 	public static void main(String[] args) throws Exception {
 		new PackageGraphWithSimpleCycles().process();
 	}
 
-	private void process() throws FileNotFoundException, IOException {
+	@Override
+	public Grapher<String> createGrapher(DependencyManager<String> manager) {
+		Grapher<String> grapher = new Grapher<String>(manager);
+		grapher.setShape(new PackageShape<String>());
+		return grapher;
+	}
+
+	@Override
+	public void graphAll(Grapher<String> grapher) throws IOException {
+		super.graphToSvg(grapher);
+	}
+
+	@Override
+	public DependencyManager<String> createManager() {
 		DependencyManager<String> manager = new DependencyManager<String>();
 		manager.add("ca.intelliware.example.sub1", "ca.intelliware.example");
 		manager.add("ca.intelliware.example.sub4", "ca.intelliware.example.sub5");
 		manager.add("ca.intelliware.example.sub5", "ca.intelliware.example.sub4");
-
-		File file = new File(SystemUtils.JAVA_IO_TMPDIR, "PackageGraphWithSimpleCycles.svg");
-		System.out.println(file.getAbsolutePath());
-		OutputStream output = new FileOutputStream(file);
-		try {
-			Grapher<String> grapher = new Grapher<String>(manager);
-			grapher.setShape(new PackageShape<String>());
-			grapher.createSvg(output);
-		} finally {
-			output.close();
-		}
+		return manager;
 	}
 }

--- a/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/RandomNodesDiagram.java
+++ b/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/RandomNodesDiagram.java
@@ -2,23 +2,18 @@ package com.electricmind.dependency.graph.shape;
 
 import java.awt.Color;
 import java.awt.Dimension;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
-import org.apache.commons.lang3.SystemUtils;
-
 import com.electricmind.dependency.DependencyManager;
 import com.electricmind.dependency.graph.Grapher;
 
-public class RandomNodesDiagram {
-	
+public class RandomNodesDiagram extends DependencyGraphTester<String> {
+
 	private final int nodes;
 	private final int edges;
 	private Random random;
@@ -34,7 +29,27 @@ public class RandomNodesDiagram {
 		new RandomNodesDiagram(50, 400).process();
 	}
 
-	private void process() throws IOException {
+
+	@Override
+	public Grapher<String> createGrapher(DependencyManager<String> manager) {
+		Grapher<String> grapher = new Grapher<String>(manager);
+		grapher.getPlot().setShapeFillColor(new Color(216, 223, 238));
+		grapher.getShape().setDimension(new Dimension(40, 40));
+		return grapher;
+	}
+
+	@Override
+	public void graphAll(Grapher<String> grapher) throws IOException {
+		super.graphToPng(grapher);
+	}
+
+	@Override
+	public String getFileNameBase() {
+		return "Random" + this.nodes + "x" + this.edges;
+	}
+
+	@Override
+	public DependencyManager<String> createManager() {
 		DependencyManager<String> manager = new DependencyManager<String>();
 
 		int edgesRemaining = this.edges;
@@ -44,7 +59,7 @@ public class RandomNodesDiagram {
 
 			if (i > 0) {
 				int numberOfEdges = (i == this.nodes-1) ? edgesRemaining : Math.min(this.random.nextInt(nodes.size()), edgesRemaining);
-				
+
 				edgesRemaining -= numberOfEdges;
 				List<Integer> temp = new ArrayList<Integer>(nodes);
 				for (int j = 0; j < numberOfEdges; j++) {
@@ -55,19 +70,6 @@ public class RandomNodesDiagram {
 			}
 			nodes.add(i);
 		}
-		System.out.println("Starting to graph");
-
-		File file = new File(SystemUtils.JAVA_IO_TMPDIR, "Random" + this.nodes + "x" + this.edges + ".png");
-		System.out.println(file.getAbsolutePath());
-		OutputStream output = new FileOutputStream(file);
-		try {
-			Grapher<String> grapher = new Grapher<String>(manager);
-			grapher.getPlot().setShapeFillColor(new Color(216, 223, 238));
-			grapher.getShape().setDimension(new Dimension(40, 40));
-			grapher.createPng(output);
-		} finally {
-			output.close();
-		}
+		return manager;
 	}
-
 }

--- a/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/SimpleArtifactGraph.java
+++ b/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/SimpleArtifactGraph.java
@@ -1,18 +1,12 @@
 package com.electricmind.dependency.graph.shape;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-
-import org.apache.commons.lang3.SystemUtils;
 
 import com.electricmind.dependency.DependencyManager;
 import com.electricmind.dependency.graph.Grapher;
 
-public class SimpleArtifactGraph {
-	
+public class SimpleArtifactGraph extends DependencyGraphTester<SimpleArtifactGraph.ArtifactName> {
+
 	public static class ArtifactName {
 		private String name;
 
@@ -23,35 +17,39 @@ public class SimpleArtifactGraph {
 		public String getName() {
 			return this.name;
 		}
-		
+
 		public String getPackaging() {
 			return "jar";
 		}
 	}
-	
+
 	public static void main(String[] args) throws Exception {
 		new SimpleArtifactGraph().process();
 	}
 
-	private void process() throws FileNotFoundException, IOException {
+	@Override
+	public Grapher<ArtifactName> createGrapher(DependencyManager<ArtifactName> manager)
+	{
+		Grapher<ArtifactName> grapher = new Grapher<>(manager);
+		ArtifactShape<ArtifactName> shape = new ArtifactShape<>();
+		shape.setLabelStrategy(new MavenArtifactLabelStrategy());
+		grapher.setShape(shape);
+		return grapher;
+	}
+
+	@Override
+	public void graphAll(Grapher<ArtifactName> grapher) throws IOException {
+		super.graphToSvg(grapher);
+	}
+
+	@Override
+	public DependencyManager<ArtifactName> createManager() {
 		DependencyManager<ArtifactName> manager = new DependencyManager<ArtifactName>();
 		ArtifactName artifact1 = new ArtifactName("com.example.thing:artifact1:1.1");
 		ArtifactName artifact2 = new ArtifactName("com.example.thing:artifact2:1.1");
 		manager.add(artifact1, artifact2);
 		manager.add(artifact1, new ArtifactName("com.example.thing:artifact3:1.1"));
 		manager.add(artifact2, new ArtifactName("com.example.thing:artifact4:1.1"));
-
-		File file = new File(SystemUtils.JAVA_IO_TMPDIR, "SimpleArtifactGraph.svg");
-		System.out.println(file.getAbsolutePath());
-		OutputStream output = new FileOutputStream(file);
-		try {
-			Grapher<ArtifactName> grapher = new Grapher<>(manager);
-			ArtifactShape<ArtifactName> shape = new ArtifactShape<>();
-			shape.setLabelStrategy(new MavenArtifactLabelStrategy());
-			grapher.setShape(shape);
-			grapher.createSvg(output);
-		} finally {
-			output.close();
-		}
+		return manager;
 	}
 }

--- a/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/SimpleNodeDiagram.java
+++ b/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/SimpleNodeDiagram.java
@@ -2,22 +2,31 @@ package com.electricmind.dependency.graph.shape;
 
 import java.awt.Color;
 import java.awt.Dimension;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-
-import org.apache.commons.lang3.SystemUtils;
 
 import com.electricmind.dependency.DependencyManager;
 import com.electricmind.dependency.graph.Grapher;
 
-public class SimpleNodeDiagram {
+public class SimpleNodeDiagram extends DependencyGraphTester<String> {
 	public static void main(String[] args) throws Exception {
 		new SimpleNodeDiagram().process();
 	}
 
-	private void process() throws IOException {
+	@Override
+	public Grapher<String> createGrapher(DependencyManager<String> manager) {
+		Grapher<String> grapher = new Grapher<String>(manager);
+		grapher.getPlot().setShapeFillColor(new Color(216, 223, 238));
+		grapher.getShape().setDimension(new Dimension(40, 40));
+		return grapher;
+	}
+
+	@Override
+	public void graphAll(Grapher<String> grapher) throws IOException {
+		super.graphToPng(grapher, 500, 500);
+	}
+
+	@Override
+	public DependencyManager<String> createManager() {
 		DependencyManager<String> manager = new DependencyManager<String>();
 		manager.add("1", "13");
 		manager.add("1", "4");
@@ -51,17 +60,6 @@ public class SimpleNodeDiagram {
 		manager.add("19", "22");
 		manager.add("21", "23");
 		manager.add("22", "23");
-
-		File file = new File(SystemUtils.JAVA_IO_TMPDIR, "SimpleNodeDiagram.png");
-		System.out.println(file.getAbsolutePath());
-		OutputStream output = new FileOutputStream(file);
-		try {
-			Grapher<String> grapher = new Grapher<String>(manager);
-			grapher.getPlot().setShapeFillColor(new Color(216, 223, 238));
-			grapher.getShape().setDimension(new Dimension(40, 40));
-			grapher.createPng(output, 500, 500);
-		} finally {
-			output.close();
-		}
+		return manager;
 	}
 }

--- a/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/SimplePackageGraph.java
+++ b/dependency-graph/src/test/java/com/electricmind/dependency/graph/shape/SimplePackageGraph.java
@@ -1,36 +1,38 @@
 package com.electricmind.dependency.graph.shape;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-
-import org.apache.commons.lang3.SystemUtils;
 
 import com.electricmind.dependency.DependencyManager;
 import com.electricmind.dependency.graph.Grapher;
 
-public class SimplePackageGraph {
-	
+public class SimplePackageGraph extends DependencyGraphTester<String> {
+
 	public static void main(String[] args) throws Exception {
 		new SimplePackageGraph().process();
 	}
 
-	private void process() throws FileNotFoundException, IOException {
+	@Override
+	public void graphToPng(Grapher<String> grapher) throws IOException {
+		graphToPng(grapher, 500, 500);
+	}
+
+	@Override
+	public Grapher<String> createGrapher(DependencyManager<String> manager) {
+		Grapher<String> grapher = new Grapher<String>(manager);
+		grapher.setShape(new PackageShape<String>());
+		return grapher;
+	}
+
+	@Override
+	public DependencyManager<String> createManager() {
 		DependencyManager<String> manager = new DependencyManager<String>();
 		manager.add("ca.intelliware.hl7.generator.xsd", "ca.intelliware.hl7.generator");
 		manager.add("ca.intelliware.hl7.referral");
+		return manager;
+	}
 
-		File file = new File(SystemUtils.JAVA_IO_TMPDIR, "SimplePackageGraph.png");
-		System.out.println(file.getAbsolutePath());
-		OutputStream output = new FileOutputStream(file);
-		try {
-			Grapher<String> grapher = new Grapher<String>(manager);
-			grapher.setShape(new PackageShape<String>());
-			grapher.createPng(output, 500, 500);
-		} finally {
-			output.close();
-		}
+	@Override
+	public String getFileNameBase() {
+		return "SimplePackageGraph";
 	}
 }


### PR DESCRIPTION
An unsolicited pull request.  I noticed there was no user interface portion to the dependencies, per se, so I thought I would whip up one for the tests in dependency-root src/test/java/com.electricmind.dependency.graph.shape as a proof of concept.  See DependencyGraphTesterUi.main in that package.

You can click on the tests to the left, and they are displayed in the area on the right.  ~~I haven't chased down what is going on, but sometimes the layout changes briefly right as you select one of the tests.~~  Here's what it looks like:

<img width="1039" height="635" alt="image" src="https://github.com/user-attachments/assets/1ea8712c-7b50-4a54-91cc-a4d1d8ba95ec" />

The major changes were:

- Made all of the graphing tests in src/test/java/com.electricmind.dependency.graph.shape extend a new abstract class DependencyGraphTester, factored out common functionality.
- Created the UI class DependencyGraphTesterUi
- Modified Grapher to make draw(Graphics2D, Rectangle2D) and initialize() public